### PR TITLE
Add the core__homedir_umask variable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ The current role maintainer_ is drybjed.
 
 .. _debops.core master: https://github.com/debops/ansible-core/compare/v0.2.4...master
 
+Added
+~~~~~
+
+- Add the ``core__homedir_umask`` variable which sets the ``ansible_local.core.homedir_umask``
+  fact. [bfabio_]
 
 `debops.core v0.2.4`_ - 2016-09-12
 ----------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -225,6 +225,11 @@ core__keyserver: 'hkp://pool.sks-keyservers.net'
 # If it's not available, this value will be used as the UUID source.
 core__uuid_random: '{{ ansible_fqdn | to_uuid }}'
                                                                    # ]]]
+# .. envvar:: core__homedir_umask [[[
+#
+# Default umask for home directories.
+core__homedir_umask: '0027'
+                                                                   # ]]]
                                                                    # ]]]
 # Core packages [[[
 # -----------------

--- a/templates/etc/ansible/facts.d/core.fact.j2
+++ b/templates/etc/ansible/facts.d/core.fact.j2
@@ -63,6 +63,7 @@ from grp import getgrall
 {%   set _ = core__tpl_facts.update({ "distribution_release": core__distribution_release }) %}
 {%   set _ = core__tpl_facts.update({ "domain": core__domain }) %}
 {%   set _ = core__tpl_facts.update({ "fqdn": core__fqdn }) %}
+{%   set _ = core__tpl_facts.update({ "homedir_umask": core__homedir_umask }) %}
 {%   set _ = core__tpl_facts.update({ "keyserver": core__keyserver }) %}
 {%   set _ = core__tpl_facts.update({ "cache_valid_time": core__cache_valid_time }) %}
 output = loads('''{{ core__tpl_facts | to_nice_json }}''')


### PR DESCRIPTION
core__homedir_umask sets the default umask for home directories.

The ansible_local.core.homedir_umask fact can be used by roles needing
that information.